### PR TITLE
[WIP] Add timestamp to builder-client observe output

### DIFF
--- a/app/server.ml
+++ b/app/server.ml
@@ -426,12 +426,12 @@ let handle t fd addr =
     begin match UM.find_opt id t.running with
       | Some (_, _, cond, out) ->
         let open Lwt.Infix in
-        Lwt_list.iter_s (fun (_ts, l) ->
-            write_cmd fd (Builder.Output (id, l)) >|= ignore)
+        Lwt_list.iter_s (fun (ts, l) ->
+            write_cmd fd (Builder.Output_timestamped (id, ts, l)) >|= ignore)
           (List.rev out) >>= fun () ->
         let rec more () =
-          Lwt_condition.wait cond >>= fun (_ts, data) ->
-          write_cmd fd (Builder.Output (id, data)) >>= function
+          Lwt_condition.wait cond >>= fun (ts, data) ->
+          write_cmd fd (Builder.Output_timestamped (id, ts, data)) >>= function
           | Ok () -> more ()
           | Error _ -> Lwt.return (Ok ())
         in

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -385,7 +385,7 @@ module Asn = struct
                    (explicit 4 (sequence3
                                   (required ~label:"uuid" uuid)
                                   (required ~label:"output" utf8_string)
-                                  (optional ~label:"timestamp" Asn.S.int)))
+                                  (optional ~label:"timestamp" int)))
                    (explicit 5 (sequence2
                                   (required ~label:"period" period)
                                   (required ~label:"job" script_job))))

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name builder)
  (public_name builder)
- (libraries unix fpath fmt logs cstruct asn1-combinators uuidm))
+ (libraries unix fpath fmt logs cstruct asn1-combinators uuidm duration))


### PR DESCRIPTION
I experienced a builder job that timed out, but the `client observe` output said it had finished. Because there were no timestamps I couldn't tell the timings of the messages I had received in `client observe` when I came back to it later.

TODO:
* [x] Verify ASN.1 backwards compatbility
* [x] Have backwards compatibility between server and client - perhaps with a new `Observe_with_timestamp` client command ?
* [ ] ~~A flag in the client command line interface to enable/disable timestamps~~