### PR TITLE
Add optional platform argument to builder-client execute

### DIFF
--- a/app/client.ml
+++ b/app/client.ml
@@ -97,9 +97,9 @@ let unschedule () remote name =
   let* () = Builder.write_cmd s (Builder.Unschedule name) in
   teardown s
 
-let execute () remote name =
+let execute () remote name platform =
   let* s = connect remote in
-  let* () = Builder.write_cmd s (Builder.Execute name) in
+  let* () = Builder.write_cmd s (Builder.Execute (name, platform)) in
   teardown s
 
 let schedule () remote name platform script period =
@@ -252,7 +252,7 @@ let reschedule_cmd =
   Term.info "reschedule"
 
 let execute_cmd =
-  Term.(term_result (const execute $ setup_log $ remote $ nam)),
+  Term.(term_result (const execute $ setup_log $ remote $ nam $ platform_opt)),
   Term.info "execute"
 
 let drop_platform_cmd =


### PR DESCRIPTION
Furthermore, `builder-client execute` doesn't reschedule the job since the semantics becomes exotic when executing a job on one platform and rescheduling the job.

Keeping it a draft for now because `add_to_front_of_queues` has become rather complicated.