### PR TITLE
worker: use timeout of 1 hour

### DIFF
--- a/app/worker.ml
+++ b/app/worker.ml
@@ -80,7 +80,7 @@ let execute_job s uuid job =
     end else (* parent *)
       let toexec = Fpath.(to_string (tmpdir / sh)) in
       let pid =
-        Unix.create_process "/bin/sh" [| "-e" ; toexec |] Unix.stdin out out
+        Unix.create_process "/bin/sh" [| "-ec" ; "timeout 1h " ^ toexec |] Unix.stdin out out
       in
       let r = Unix.waitpid [] pid in
       (try


### PR DESCRIPTION
//cc @reynir AFAICT Linux and BSD support `timeout 1h`.... we could as well use some fancy Lwt or another process, but I fear that'd make the worker way more complex than is good.