### PR TITLE
client: observe, avoid output of the uuid.

### DIFF
--- a/app/client.ml
+++ b/app/client.ml
@@ -39,8 +39,8 @@ let observe_uuid uuid remote =
   let rec read () =
     let* cmd = Builder.read_cmd s in
     match cmd with
-    | Output_timestamped _ ->
-      Logs.app (fun m -> m "%a" Builder.pp_cmd cmd);
+    | Output_timestamped (_uuid, ts, data) ->
+      Logs.app (fun m -> m "%a %s" Duration.pp ts data);
       read ()
     | _ ->
       if cmd <> Builder.Success then


### PR DESCRIPTION
There's only ever a single observe going on, thus no need to print the uuid in each line.